### PR TITLE
fix(signout): Change redirection url from blank to signin

### DIFF
--- a/users/views.py
+++ b/users/views.py
@@ -64,4 +64,4 @@ def delete_user(request):
 
 def signout(request):
     logout(request)
-    return JsonResponse({'result': True, 'redirect': '', 'statusCode': 200})
+    return JsonResponse({'result': True, 'redirect': reverse('users:signin'), 'statusCode': 200})


### PR DESCRIPTION
이유는 모르겠지만 로그인한 상태에서 order 페이지에 들어간 뒤에 signout을 해보세요. 

```
Not Found: /accounts/login/
```
명시한 적도 없는 url을 요청하는게 어찌 된 명문인지 모르겠지만 어쨌든 404 에러가 뜨는군요... 

PR 보시고 계시다면 아직 병합하지 마시고 main 브랜치에서 위의 단계를 밟아보세요. 404 에러가 저만 뜨는 거라면 저의 문제인거고 아니면 수정해야 할 버그인 겁니다.

해결방법은 간단합니다. 공백으로 채워져 있던 `redirect` 필드를 로그인 페이지로 보내버렸습니다.