### PR TITLE
feat(purchases): Add kakaopay API

### DIFF
--- a/purchases/models.py
+++ b/purchases/models.py
@@ -10,3 +10,6 @@ class Purchase(models.Model):
     
     stripe_checkout_session_id = models.CharField(max_length=220, blank=True, null=True)
     stripe_price = models.IntegerField(default=0)
+
+    kakaopay_checkout_tid = models.CharField(max_length=20, blank=True, null=True)
+    kakaopay_price = models.IntegerField(default=0)

--- a/purchases/urls.py
+++ b/purchases/urls.py
@@ -7,4 +7,7 @@ urlpatterns = [
     path('success/', views.purchase_success_view, name='success'),
     path('stopped/', views.purchase_stopped_view, name='stopped'),
     path('orders/', views.purchase_order_view, name='orders'),
+    path('kakaopay_start/', views.kakaopay_start_view, name='kakaopay_start'),
+    path('kakaopay_success/', views.kakaopay_success_view, name='kakaopay_success'),
+    path('kakaopay_stop/', views.kakaopay_stop_view, name='kakaopay_stop'),
 ]

--- a/purchases/views.py
+++ b/purchases/views.py
@@ -10,7 +10,7 @@ from core.env import config
 STRIPE_SECRET_KEY = config("STRIPE_SECRET_KEY", default=None)
 stripe.api_key = STRIPE_SECRET_KEY
 KAKAOPAY_SECRET_KEY = config("KAKAOPAY_SECRET_KEY", default=None)
-kakaopay_amdin_key = KAKAOPAY_SECRET_KEY
+kakaopay_admin_key = KAKAOPAY_SECRET_KEY
 
 
 @login_required
@@ -123,7 +123,7 @@ def kakaopay_start_view(request):
 
     url = f'https://kapi.kakao.com/v1/payment/ready'
     header = {
-        'Authorization': f'KakaoAK {kakaopay_amdin_key}'
+        'Authorization': f'KakaoAK {kakaopay_admin_key}'
     }
 
     data = {
@@ -164,7 +164,7 @@ def kakaopay_success_view(request):
     
     url = f'https://kapi.kakao.com/v1/payment/approve'
     header = {
-        'Authorization': f'KakaoAK {kakaopay_amdin_key}'
+        'Authorization': f'KakaoAK {kakaopay_admin_key}'
     }
     data = {
         'cid': 'TC0ONETIME', # 테스트용 기본 가맹점 키 값

--- a/purchases/views.py
+++ b/purchases/views.py
@@ -1,4 +1,5 @@
 from django.shortcuts import render, redirect
+import requests
 from products.models import Product
 from .models import Purchase
 from django.contrib.auth.decorators import login_required
@@ -8,6 +9,9 @@ import stripe, json
 from core.env import config
 STRIPE_SECRET_KEY = config("STRIPE_SECRET_KEY", default=None)
 stripe.api_key = STRIPE_SECRET_KEY
+KAKAOPAY_SECRET_KEY = config("KAKAOPAY_SECRET_KEY", default=None)
+kakaopay_amdin_key = KAKAOPAY_SECRET_KEY
+
 
 @login_required
 def purchase_start_view(request):
@@ -86,3 +90,107 @@ def purchase_stopped_view(request):
 def purchase_order_view(request):
     purchases = Purchase.objects.filter(user=request.user, completed=True)
     return render(request, "orders.html", {"purchases": purchases})
+
+
+@login_required
+def kakaopay_start_view(request):
+    BASE_ENDPOINT = f'http://{request.get_host()}'
+    data = json.loads(request.body)
+    handle = data.get('handle')
+
+    if not request.method == "POST":
+        return HttpResponseBadRequest()
+    if not request.user.is_authenticated:
+        return HttpResponseBadRequest()
+    
+    product = Product.objects.get(handle=handle)
+    if product is None:
+        return HttpResponseBadRequest()
+
+    purchase = Purchase.objects.create(user=request.user, product=product)
+    request.session['purchase_id'] = purchase.id
+
+    success_path = reverse("purchases:kakaopay_success")
+    if not success_path.startswith("/"):
+        success_path = f"/{success_path}"
+
+    stopped_path = reverse("purchases:kakaopay_stop")
+    if not stopped_path.startswith("/"):
+        stopped_path = f"/{stopped_path}"
+
+    success_url = f"{BASE_ENDPOINT}{success_path}"
+    stopped_url = f"{BASE_ENDPOINT}{stopped_path}"
+
+    url = f'https://kapi.kakao.com/v1/payment/ready'
+    header = {
+        'Authorization': f'KakaoAK {kakaopay_amdin_key}'
+    }
+
+    data = {
+        'cid': 'TC0ONETIME', # 테스트용 기본 가맹점 키 값
+        'partner_order_id': purchase.id,
+        'partner_user_id': 'partner_user_id', # 테스트용 기본 데이터
+        'item_name': product.name,
+        'quantity': 1,
+        'total_amount': int(product.price),
+        'tax_free_amount': 0,
+        'approval_url': success_url,
+        'fail_url': stopped_url,
+        'cancel_url': stopped_url
+    }
+    
+    res = requests.post(url, data=data, headers=header)
+    result = res.json()
+    
+    purchase.kakaopay_checkout_tid = result['tid']
+    purchase.kakaopay_price = product.price
+    purchase.save()
+    return JsonResponse({'redirect': result['next_redirect_pc_url']})
+
+
+@login_required
+def kakaopay_success_view(request):
+    purchase_id = request.session.get('purchase_id')
+    if not(purchase_id):
+        return HttpResponseBadRequest()
+    
+    purchase = Purchase.objects.get(id=purchase_id)
+    if purchase is None:
+        return HttpResponseBadRequest()
+    
+    tid = purchase.kakaopay_checkout_tid
+    if not(tid):
+        return HttpResponseBadRequest()
+    
+    url = f'https://kapi.kakao.com/v1/payment/approve'
+    header = {
+        'Authorization': f'KakaoAK {kakaopay_amdin_key}'
+    }
+    data = {
+        'cid': 'TC0ONETIME', # 테스트용 기본 가맹점 키 값
+        'tid': tid,
+        'partner_order_id': purchase_id,
+        'partner_user_id': 'partner_user_id', # 테스트용 기본 데이터
+        'pg_token': request.GET['pg_token']
+    }
+
+    res = requests.post(url, data=data, headers=header)
+    result = res.json()
+    
+    if result.get('msg'):
+        return JsonResponse({'error': 'Purchase not found'})
+    purchase.completed = True
+    purchase.save()
+    del request.session['purchase_id']
+    return redirect('/purchases/orders/')
+    
+
+@login_required
+def kakaopay_stop_view(request):
+    purchase_id = request.session.get("purchase_id")
+    if purchase_id:
+        purchase = Purchase.objects.get(id=purchase_id)
+        purchase.delete()
+        del request.session['purchase_id']
+        return redirect(purchase.product.get_absolute_url())
+    return HttpResponse("Purchase not found")

--- a/templates/book_detail.html
+++ b/templates/book_detail.html
@@ -3,20 +3,33 @@
 {% block title %}Book Detail{% endblock title%}
 
 {% block content %}
+{% block stylesheet %}
+<style>
 {% if book.user != request.user %}
-  <style>
     .hidden {
         visibility: hidden;
     }
-  </style>
 {% endif %}
+    .kakaopay-btn {
+        background: url(https://developers.kakao.com/tool/resource/static/img/button/pay/payment_icon_yellow_small.png) no-repeat center;
+        background-size: cover;
+        border: none;
+        width: 80px;
+        height: 32px;
+    }
+
+    .kakaopay-btn:hover {
+        filter: brightness(70%);
+    }
+</style>
+{% endblock stylesheet %}
   <h1>{{ book.name }}</h1>
   <p>Handle: {{ book.handle }}</p>
   <p>Price: {{ book.price }}</p>
   <p>User: {{ book.user }}</p>
   <p>Stock: {{ book.stock }}</p>
   <button type="submit" id="purchaseBtn">구매</button>
-  <button type="submit" id="kakaopayBtn">카카오페이</button>
+  <button type="submit" id="kakaopayBtn" class="kakaopay-btn"></button>
 
   <span class="hidden"><a href="/products/book/update/{{ book.handle }}/"><input type="button" value="수정"></a></span>
   <button type="submit" id="deleteBtn" class="hidden">삭제</button>

--- a/templates/book_detail.html
+++ b/templates/book_detail.html
@@ -16,6 +16,7 @@
   <p>User: {{ book.user }}</p>
   <p>Stock: {{ book.stock }}</p>
   <button type="submit" id="purchaseBtn">구매</button>
+  <button type="submit" id="kakaopayBtn">카카오페이</button>
 
   <span class="hidden"><a href="/products/book/update/{{ book.handle }}/"><input type="button" value="수정"></a></span>
   <button type="submit" id="deleteBtn" class="hidden">삭제</button>
@@ -79,7 +80,31 @@
     .catch(error => console.log(error));
 });
 
-
+document.getElementById('kakaopayBtn').addEventListener('click', function () {
+    const handle = '{{ book.handle }}';
+    const url = `/purchases/kakaopay_start/`;
+    fetch(url, {
+        method: 'POST',
+        headers: {
+            'X-CSRFToken': csrftoken,
+            'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({ handle: handle })
+    })
+    .then(response => response.json())
+    .then(data => {
+        if (data.redirect) {
+            window.location.href = data.redirect;
+        } else if (data.statusCode == 400) {
+            alert('잘못된 요청입니다');
+        } else if (data.statusCode == 401) {
+            alert('로그인이 필요합니다');
+        } else if (data.statusCode == 403) {
+            alert('구매할 수 없는 상품입니다');
+        }
+    })
+    .catch(error => console.log(error));
+});
     </script>
 {% endblock content %}
 

--- a/templates/orders.html
+++ b/templates/orders.html
@@ -16,7 +16,13 @@
         {% for purchase in purchases reversed %}
           <tr>
             <td class="border border-gray-300 px-4 py-2">{{ purchase.product.name }}</td>
-            <td class="border border-gray-300 px-4 py-2">${{ purchase.stripe_price }}</td>
+            <td class="border border-gray-300 px-4 py-2">
+            {% if purchase.stripe_price == 0 %}
+            {{ purchase.kakaopay_price }}원
+            {% else %}
+            ${{ purchase.stripe_price }}
+            {% endif %}
+            </td>
             <td class="border border-gray-300 px-4 py-2">{% if purchase.completed %}Yes{% else %}No{% endif %}</td>
             <td class="border border-gray-300 px-4 py-2">
               

--- a/users/views.py
+++ b/users/views.py
@@ -64,4 +64,4 @@ def delete_user(request):
 
 def signout(request):
     logout(request)
-    return JsonResponse({'result': True, 'redirect': '', 'statusCode': 200})
+    return JsonResponse({'result': True, 'redirect': reverse('users:signin'), 'statusCode': 200})


### PR DESCRIPTION
카카오페이 결제 기능 추가
주의) KAKAOPAY_SECRET_KEY는 .env파일에 개인의 카카오API를 발급받아 사용하시면 됩니다.
* 상품의 디테일 페이지에 카카오페이 버튼 추가
* 카카오페이 버튼 클릭 시, QR결제 페이지로 이동
* QR페이지에서 X버튼으로 결제 취소 시, 해당 상품 디테일 페이지로 이동
* QR결제 진행 시, 결제 확인 페이지 이동 후 최종 결제 후 상품 결제 목록 페이지로 이동
* Purchase model에 kakaopay_checkout_tid, kakaopay_price 속성 추가
* 상품 디테일 페이지 카카오페이 버튼 스타일 추가