### PR TITLE
refactor(cart, checkout): Change endpoints

### DIFF
--- a/carts/urls.py
+++ b/carts/urls.py
@@ -1,14 +1,14 @@
 from django.urls import path
-from .views import cart_add, cart_list, cart_update, cart_delete, product_list, order_detail, order_product_detail
+from .views import cart_add, cart_view, cart_update, cart_delete, cart_list, checkout_view, checkout_list
 
 app_name = 'carts'
 
 urlpatterns = [
-    path('', cart_list, name='cart_list'),
-    path('product/', product_list, name='product_list'),
-    path('update/', cart_update, name='cart_update'),
-    path('add/', cart_add, name='cart_add'),
-    path('delete/', cart_delete, name='cart_delete'),
-    path('order_detail/', order_detail, name='order_detail'),
-    path('order_detail/order_product_detail/', order_product_detail, name='order_product_detail'),
+    path('', cart_view, name='view'),
+    path('list/', cart_list, name='list'),
+    path('update/', cart_update, name='update'),
+    path('add/', cart_add, name='add'),
+    path('delete/', cart_delete, name='delete'),
+    path('checkout/view/', checkout_view, name='checkout_view'),
+    path('checkout/list/', checkout_list, name='checkout_list'),
 ]

--- a/carts/views.py
+++ b/carts/views.py
@@ -2,7 +2,7 @@ import re
 import json
 from django.shortcuts import render, get_object_or_404
 from django.contrib.auth.decorators import login_required
-from django.urls import Resolver404
+from django.urls import Resolver404, reverse
 from django.views.decorators.http import require_http_methods
 from django.http import HttpResponse, JsonResponse
 from django.core.exceptions import FieldDoesNotExist
@@ -37,14 +37,14 @@ def cart_add(request):
 
 @login_required(login_url="/users/signin")
 @require_http_methods(['GET'])
-def cart_list(request) -> HttpResponse:
+def cart_view(request) -> HttpResponse:
     """returns: HttpResponse that will query products"""
     items = Cart.objects.filter(user = request.user)
     return render(request, "cart_list.html", {"items": items})
 
 
 @require_http_methods(['GET'])
-def product_list(request) -> JsonResponse:
+def cart_list(request) -> JsonResponse:
     """returns: JsonResponse that contains products"""
     filtered = Cart.objects \
         .filter(user=request.user)
@@ -69,13 +69,13 @@ def product_list(request) -> JsonResponse:
 
 @login_required(login_url="/users/signin")
 @require_http_methods(['GET'])
-def order_detail(request) -> HttpResponse:
+def checkout_view(request) -> HttpResponse:
     user = Cart.objects.filter(user=request.user).values("user_id")
-    return render(request, "order_detail.html", {"items": user})
+    return render(request, "checkout.html", {"items": user})
 
 
 @require_http_methods(['GET'])
-def order_product_detail(request) -> JsonResponse:
+def checkout_list(request) -> JsonResponse:
     """returns: JsonResponse that contains products"""
     filtered = Cart.objects.filter(user=request.user, checked=True)
 
@@ -151,7 +151,7 @@ def cart_update(request):
     return JsonResponse(
         {"message": "Succesfully update items",
         "statusCode": 200, 
-        "redirect_url": "order_detail"})
+        "redirect_url": reverse("carts:checkout_view")})
 
 
 

--- a/templates/cart_list.html
+++ b/templates/cart_list.html
@@ -78,7 +78,7 @@
     */
     let items = [];
 
-    await fetch("product", {
+    await fetch("{% url 'carts:list' %}", {
         method: "GET",
         headers: {
             "Content-Type": "application/json",
@@ -130,7 +130,7 @@
         children.delete.addEventListener("click", (e) => {
             e.preventDefault();
 
-            fetch('delete/', {
+            fetch("{% url 'carts:delete' %}", {
                 method: 'DELETE',
                 headers: {
                     'Content-Type': 'application/json',
@@ -156,7 +156,6 @@
     }
 
     document.getElementById("order-btn").addEventListener("click", function () {
-        const update_url = "/carts/update/";
 
         const create_patch_item = (op, path, value) => {
             return {
@@ -169,7 +168,7 @@
         const product_items = items.map((e) => e.product);
         const patch_items = product_items.map((e) => create_patch_item('replace', e.productHandle, e));
         
-        fetch(update_url, {
+        fetch("{% url 'carts:update' %}", {
             method: 'PATCH',
             headers: {
                 'Content-Type': 'application/json',

--- a/templates/checkout.html
+++ b/templates/checkout.html
@@ -84,7 +84,7 @@
 
     // JsonResponse를 통해 상품리스트를 얻어온다.
     let items = [];
-    await fetch("order_product_detail", {
+    await fetch("{% url 'carts:checkout_list' %}", {
         method: "GET",
         headers: {
             "Content-Type": "application/json",
@@ -127,8 +127,7 @@
                 "product__handle": "상품2",
            }
         ]
-        const url = `/purchases/kakaopay_start/`;
-        fetch(url, {
+        fetch("{% url 'purchases:kakaopay_start' %}", {
             method: 'POST',
             headers: {
                 'X-CSRFToken': csrftoken,

--- a/templates/nav.html
+++ b/templates/nav.html
@@ -20,7 +20,7 @@
           <a href="{% url 'users:profile' %}" class="nav-link">Profile</a>
         </li>
         <li class="nav-link">
-          <a href="{% url 'carts:cart_list' %}" class="nav-link">Cart</a>
+          <a href="{% url 'carts:view' %}" class="nav-link">Cart</a>
         </li>
         <li class="nav-link">
           <a href="{% url 'purchases:orders' %}" class="nav-link">Order</a>


### PR DESCRIPTION
described in cart, order 함수명 리팩토링 필요 #79

주문 상세페이지는 이제 "checkout"이라는 이름으로 불리웁니다. 주문내역 "order"와의 혼동을 줄일 수 있군요.