### PR TITLE
fix(cart): Resolve corner case that Cart quantity exceeds Product stock

### DIFF
--- a/carts/views.py
+++ b/carts/views.py
@@ -1,5 +1,6 @@
 import re
 import json
+from django.forms import ValidationError
 from django.shortcuts import render, get_object_or_404
 from django.contrib.auth.decorators import login_required
 from django.urls import Resolver404, reverse
@@ -133,6 +134,11 @@ def cart_update(request):
             .exists()
             for x in json_request]):
         raise FieldDoesNotExist()
+    for each_request in json_request:
+        quantity = each_request['value']['quantity']
+        stock = products.get(product_id=get_handle_from_path(each_request['path'])).product.stock
+        if not quantity <= stock:
+            raise ValidationError(f"Cart.quantity ({quantity}) exceeds Product.stock ({stock})")
 
     # let's DO update!
     for each_patch in json_request:

--- a/carts/views.py
+++ b/carts/views.py
@@ -55,7 +55,8 @@ def cart_list(request) -> JsonResponse:
                 "quantity", 
                 "product__handle",
                 "product__name",
-                "product__price")
+                "product__price",
+                "product__stock")
 
     image_urls = [cart.product.get_image_url() for cart in filtered]
     book_urls = [cart.product.get_absolute_url() for cart in filtered]

--- a/static/js/cartItem.js
+++ b/static/js/cartItem.js
@@ -24,6 +24,9 @@ export function convertToJsObject(item) {
 export function itemHtmlMapper(item) {
   const tr = document.createElement("tr");
   const handle = item.productHandle;
+  const stock = item['stock'];
+  item['quantity'] = Math.min(item['quantity'], stock);
+  const quantity = item['quantity'];
 
   for (const key of order) {
     const value = item[key];
@@ -37,7 +40,8 @@ export function itemHtmlMapper(item) {
           id="checkbox-${handle}" 
           type="checkbox" 
           label="cartItem"
-          ${value ? "checked" : ""}
+          ${value && quantity > 0 ? "checked" : ""}
+          ${quantity <= 0 ? "disabled" : ""}
         >
         `;
         break;
@@ -48,6 +52,7 @@ export function itemHtmlMapper(item) {
           id="quantity-${handle}" 
           type="number" 
           label="cartItem"
+          min="0"
           value="${value}">
         `;
         break;

--- a/static/js/constants.js
+++ b/static/js/constants.js
@@ -7,6 +7,7 @@ export const elementResponseMapper = {
   productPrice: "product__price",
   imageUrl: "image_url",
   bookUrl: "book_url",
+  stock: "product__stock",
 };
 
 export const cartElementOrder = [

--- a/templates/cart_list.html
+++ b/templates/cart_list.html
@@ -118,13 +118,23 @@
             //NOTE - doesn't fetch, only change innerText of `productPrice`
 
             const originalPrice = parseInt(item.product.productPrice);
+            const stock = parseInt(item.product.stock);
             const quantity = parseInt(children.quantity.value);
-            const resultPrice = originalPrice * quantity;
 
-            item.product.quantity = quantity;
-            children.productPrice.innerText = `${resultPrice} 원`;
+            if (quantity <= stock) {
+                // ok
+                const resultPrice = originalPrice * quantity;
 
-            total.setValue(totalSum(items.map((e) => e.product)));
+                item.product.quantity = quantity;
+                children.productPrice.innerText = `${resultPrice} 원`;
+
+                total.setValue(totalSum(items.map((e) => e.product)));
+            } else {
+                // too many quantity
+                alert("재고보다 많은 양을 장바구니에 담을 수 없습니다.");
+                children.quantity.value = stock;
+            }
+
         });
 
         children.delete.addEventListener("click", (e) => {

--- a/templates/cart_list.html
+++ b/templates/cart_list.html
@@ -121,20 +121,26 @@
             const stock = parseInt(item.product.stock);
             const quantity = parseInt(children.quantity.value);
 
-            if (quantity <= stock) {
+            if (quantity <= 0) {
+                // you cannot buy 0 product
+                item.product.checked = false;
+                children.checked.checked = false;
+                children.checked.disabled = true;
+            }
+            else if (quantity <= stock) {
                 // ok
+                children.checked.disabled = false;
+                children.checked.dispatchEvent(new Event("changed"));
                 const resultPrice = originalPrice * quantity;
 
                 item.product.quantity = quantity;
                 children.productPrice.innerText = `${resultPrice} 원`;
-
-                total.setValue(totalSum(items.map((e) => e.product)));
             } else {
                 // too many quantity
                 alert("재고보다 많은 양을 장바구니에 담을 수 없습니다.");
                 children.quantity.value = stock;
             }
-
+            total.setValue(totalSum(items.map((e) => e.product)))
         });
 
         children.delete.addEventListener("click", (e) => {
@@ -163,6 +169,9 @@
             // sum of checked product's price
             total.setValue(totalSum(items.map((e) => e.product)));
         });
+        //SECTION - Dispatch Events
+        children.quantity.dispatchEvent(new Event("change"));
+        //!SECTION
     }
 
     document.getElementById("order-btn").addEventListener("click", function () {
@@ -196,5 +205,7 @@
             });
     });
     //!SECTION
+
+
 </script>
 {% endblock content %}


### PR DESCRIPTION
# What I have done

1. 프론트엔드 단에서 상품 수량을 0~`product.stock` 사이를 유지하게 강제했습니다. input에 stock을 초과하는 값을 넣을 시 alert 및 값을 강제로 최대치로 조정합니다.

1을 완수하기 위하여 `carts.views.cart_list` 함수를 약간 수정했습니다. stock을 JSON 필드에 추가하여야 프론트 독립적으로 초과 여부를 알 수 있기 때문입니다.

상품 수량이 0이 되면 선택할 수 없게 아예 체크박스를 틀어막아버렸습니다. (checked = false, disabled = true)

2. 악성 유저가 포스트맨 따위를 사용하여 많은 수량을 주문하게 될 경우 1번만으로는 해결할 수 없다는 치명적인 문제가 존재합니다. 따라서 백엔드 자체에서 유효성 검사를 수행합니다.

처음엔 [Validators](https://docs.djangoproject.com/en/4.2/ref/validators/) 문서를 읽으며 커스텀 validator를 만들 생각을 하였으나, 인자를 하나밖에 넣을 수 없다는 한계에 그냥 코드 중간에 validation을 수행하게 만들었습니다. 깔끔집착 멈춰 ✋

![ValidationError](https://github.com/ESTsoft-Book-Project/bookstore/assets/18757823/a9498ceb-e5d3-492f-bca9-00f60a103b64)

---
resolve #93 
