### PR TITLE
hotfix(signout): GET request still exist in profile

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -25,26 +25,27 @@
 <body>
     {% include 'nav.html' %}
 
-    {% if user.is_authenticated %}
-        <script>
-            document.querySelector('#sign_out_btn').addEventListener('click', signout);
-            function signout(e) {
-                e.preventDefault();
-                fetch('{% url "users:signout" %}', {
-                    method: 'POST',
-                    headers: {
-                        'Content-Type': 'application/json',
-                        'X-CSRFToken': getCookie("csrftoken")
-                    }
+    <script>
+        $sign_out_btn = document.querySelector('#sign_out_btn');
+        if ($sign_out_btn) {
+            $sign_out_btn.addEventListener('click', signout);
+        }
+        function signout(e) {
+            e.preventDefault();
+            fetch('{% url "users:signout" %}', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'X-CSRFToken': getCookie("csrftoken")
+                }
+            })
+                .then(response => response.json())
+                .then(data => {
+                    window.location.href = data.redirect_url;
                 })
-                    .then(response => response.json())
-                    .then(data => {
-                        window.location.href = data.redirect_url;
-                    })
-                    .catch(error => console.log(error));
-            };
-        </script>
-    {% endif %}
+                .catch(error => console.log(error));
+        };
+    </script>
 
     {% block content %}
         {% comment %} Here main magic goes! {% endcomment %}


### PR DESCRIPTION
base.html에서 `{% if user.is_authenticated %}` 구문이 profile 페이지에서 작동하지 않아 `a` 태그가 그대로 GET을 요청하는 문제였습니다. #74 에서 언급했던 405 에러가 완전히 고쳐진 것이 아니었습니다. 

의도한 대로 동작하지 않는 저 장고 템플릿을 제거하고 `sign_out_btn`엘리먼트를 무조건 가져오도록 변경했습니다. 로그인이 안 됐다면 null을 반환할 것이고, 이때 안전하게 null check를 한 뒤에 event listener를 달도록 수정했습니다.