### PR TITLE
fix(profile): Profile page requires password input from now

### DIFF
--- a/core/settings.py
+++ b/core/settings.py
@@ -110,7 +110,7 @@ SOCIALACCOUNT_LOGIN_ON_GET = True
 ACCOUNT_SIGNUP_REDIRECT_URL = "/users/profile/"
 
 LOGIN_REDIRECT_URL = "/"
-LOGOUT_REDIRECT_URL = "/"
+LOGOUT_REDIRECT_URL = "/users/login/"
 
 WSGI_APPLICATION = "core.wsgi.application"
 

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -17,21 +17,20 @@
         {% csrf_token %}
         <h1>프로필</h1>
         <label for="email">이메일:</label>
-        <input type="email" id="email" name="email" value="{{ user.email }}" readonly /><br /><br />
+        <input type="email" id="email" name="email" value="{{ user.email }}" /><br /><br />
 
         <label for="nickname">닉네임:</label>
         <input type="text" id="nickname" name="nickname" value="{{ user.nickname }}" placeholder="닉네임을 입력해 주세요!" required /><br /><br />
 
-        <!-- <label for="password">비밀번호:</label> -->
-        <!-- <input type="password" id="password" name="password" /><br /><br /> -->
-        <input type="submit" value="수정하기" />
+        <label for="password">비밀번호 확인:</label>
+        <input type="password" id="password" name="password" /><br /><br />
+        <input type="submit" value="수정하기" class="btn btn-primary m-2" />
     </form>
-
-    <div><a href="{% url 'users:updatepassword' %}" class="btn btn-primary">비밀번호 수정</a></div>
+    <a href="{% url 'users:updatepassword' %}" class="btn btn-primary m-2">비밀번호 수정</a>
 
     <form id="userDelete" method="post">
         {% csrf_token %}
-        <input type="submit" value="계정 삭제하기" />
+        <input type="submit" value="계정 삭제하기" class="btn btn-primary m-2" />
     </form>
 
     <script>
@@ -43,11 +42,9 @@
                 "nickname": document.querySelector("#nickname").value,
             }
 
-            /*
             if (document.querySelector("#password").value) {
                 userData.password = document.querySelector("#password").value;
             }
-            */
 
             fetch("/users/profile/", {
                 method: "PATCH",
@@ -57,10 +54,33 @@
                 },
                 body: JSON.stringify(userData)
             })
-                .then(res => res.json())
+                .then(res => {
+                    if (res.status !== 200) {
+                        return Promise.reject(res);
+                    }
+                    return res.json();
+                })
                 .then(data => {
                     alert(data.message)
                     window.location.href = data.redirect_url
+                }).catch(error => {
+                    if (typeof error.json === "function") {
+                        error.json()
+                            .then(jsonError => {
+                                let errorMsg = "";
+                                for (const [cause, desc] of Object.entries(jsonError)) {
+                                    errorMsg = errorMsg.concat(`${cause}: ${desc}\n`);
+                                }
+                                alert(errorMsg);
+                            })
+                            .catch((e) => {
+                                alert("알 수 없는 에러 발생! 콘솔을 확인하세요.");
+                                console.error(e);
+                            })
+                    } else {
+                        alert("알 수 없는 에러 발생! 콘솔을 확인하세요.");
+                        console.error(e);
+                    }
                 });
         });
 

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -22,10 +22,12 @@
         <label for="nickname">닉네임:</label>
         <input type="text" id="nickname" name="nickname" value="{{ user.nickname }}" placeholder="닉네임을 입력해 주세요!" required /><br /><br />
 
-        <label for="password">비밀번호:</label>
-        <input type="password" id="password" name="password" /><br /><br />
+        <!-- <label for="password">비밀번호:</label> -->
+        <!-- <input type="password" id="password" name="password" /><br /><br /> -->
         <input type="submit" value="수정하기" />
     </form>
+
+    <div><a href="{% url 'users:updatepassword' %}" class="btn btn-primary">비밀번호 수정</a></div>
 
     <form id="userDelete" method="post">
         {% csrf_token %}
@@ -41,9 +43,11 @@
                 "nickname": document.querySelector("#nickname").value,
             }
 
+            /*
             if (document.querySelector("#password").value) {
                 userData.password = document.querySelector("#password").value;
             }
+            */
 
             fetch("/users/profile/", {
                 method: "PATCH",

--- a/templates/updatepassword.html
+++ b/templates/updatepassword.html
@@ -1,0 +1,108 @@
+{% extends 'base.html' %}
+
+
+{% block content %}
+<h1>비밀번호 변경</h1>
+<form id="updatePassword">
+    {% csrf_token %}
+    <div>
+        <div>
+            <label for="password">기존 비밀번호</label>
+        </div>
+        <div id="error-password" class="text-danger">
+        </div>
+        <div>
+            <input type="password" id="password" name="password">
+        </div>
+    </div>
+    <div>
+        <div>
+            <label for="password1">새 비밀번호</label>
+        </div>
+        <div id="error-password1" class="text-danger">
+        </div>
+        <div>
+            <input type="password" id="password1" name="password1">
+        </div>
+    </div>
+    <div>
+        <div>
+            <label for="password2">새 비밀번호 (확인)</label>
+        </div>
+        <div id="error-password2" class="text-danger">
+        </div>
+        <div>
+            <input type="password" id="password2" name="password2">
+        </div>
+    </div>
+    <div id="error-other" class="text-danger"></div>
+    <div>
+        <input type="submit" value="수정하기">
+    </div>
+</form>
+
+<script>
+    $updatePassword = document.getElementById("updatePassword");
+    $password = document.getElementById("password");
+    $errorPassword = document.getElementById("error-password");
+    $password1 = document.getElementById("password1");
+    $errorPassword1 = document.getElementById("error-password1");
+    $password2 = document.getElementById("password2");
+    $errorPassword2 = document.getElementById("error-password2");
+    $errorOther = document.getElementById("error-other");
+
+    if ($updatePassword) {
+        $updatePassword.addEventListener("submit", (e) => {
+            e.preventDefault();
+            $errorPassword.innerHTML = "";
+            $errorPassword1.innerHTML = "";
+            $errorPassword2.innerHTML = "";
+
+            const passwords = {
+                "password": $password.value,
+                "password1": $password1.value,
+                "password2": $password2.value,
+            };
+
+            fetch("{% url 'users:updatepassword' %}", {
+                method: "PATCH",
+                headers: {
+                    "Content-Type": "application/json",
+                    "X-CSRFToken": getCookie("csrftoken")
+                },
+                body: JSON.stringify(passwords)
+            }).then(res => {
+                if (!res.ok) {
+                    return Promise.reject(res);
+                }
+                return res.json();
+            }).then(data => {
+                if (data.message) {
+                    alert(data.message);
+                }
+                if (data.redirect_url) {
+                    window.location.pathname = data.redirect_url;
+                }
+                // window.location.href = "{% url 'users:signin' %}";
+            }).catch(error => {
+                if (typeof error.json === "function") {
+                    error.json().then(jsonError => {
+                        for (const key in jsonError) {
+                            let $hint = document.getElementById("error-" + key);
+                            if ($hint) {
+                                $hint.innerHTML = jsonError[key];
+                            } else {
+                                $errorOther.innerHTML = jsonError["non_field_errors"];
+                            }
+                        }
+                    }).catch(genericError => {
+                        alert(error);
+                    });
+                } else {
+                    alert(error);
+                }
+            });
+        });
+    }
+</script>
+{% endblock content %}

--- a/users/serializers.py
+++ b/users/serializers.py
@@ -43,13 +43,23 @@ class SignInSerializer(serializers.Serializer):
 
 
 class ProfileSerializer(serializers.ModelSerializer):
-    password = serializers.CharField(write_only=True)
+    """password는 확인하는 용도로 사용, email, nickname을 수정하는데 사용.
+    참고: 초기값이 마치 placeholder처럼 지정되어있어야 한다."""
+    password = serializers.CharField(write_only=True, required=True)
     email = serializers.EmailField(max_length=150)
-    nickname = serializers.CharField(write_only=True)
+    nickname = serializers.CharField(max_length=255)
 
     class Meta:
         model = User
         fields = ["email", "nickname", "password"]
+
+    def update(self, instance: User, validated_data):
+        if not instance.check_password(validated_data.get("password")):
+            raise serializers.ValidationError({"password": "사용자 비밀번호가 틀렸습니다."})
+        instance.email = validated_data.get("email")
+        instance.nickname = validated_data.get("nickname")
+        instance.save()
+        return instance
 
 
 class PasswordSerializer(serializers.ModelSerializer):

--- a/users/serializers.py
+++ b/users/serializers.py
@@ -1,6 +1,8 @@
 from rest_framework import serializers
+from rest_framework.exceptions import APIException
 from .models import User
 from django.contrib.auth import password_validation
+from django.db import IntegrityError
 
 
 class UserSerializer(serializers.ModelSerializer):
@@ -58,7 +60,10 @@ class ProfileSerializer(serializers.ModelSerializer):
             raise serializers.ValidationError({"password": "사용자 비밀번호가 틀렸습니다."})
         instance.email = validated_data.get("email")
         instance.nickname = validated_data.get("nickname")
-        instance.save()
+        try:
+            instance.save()
+        except IntegrityError as e:
+            raise APIException(detail=f"사용할 수 없는 필드입니다.\n{e}") from e
         return instance
 
 

--- a/users/urls.py
+++ b/users/urls.py
@@ -15,7 +15,7 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 from django.urls import path
-from users.views import signup, signin, signout, profile, delete_user
+from users.views import signup, signin, signout, profile, delete_user, updatepassword
 
 app_name = "users"
 
@@ -23,6 +23,7 @@ urlpatterns = [
     path("signup/", signup, name="signup"),
     path("signin/", signin, name="signin"),
     path('signout/', signout, name='signout'),
+    path("signout/updatepassword/", updatepassword, name="updatepassword"),
     path("profile/", profile, name="profile"),
     path("deleteUser/", delete_user, name="delete_user"),
 ]

--- a/users/views.py
+++ b/users/views.py
@@ -7,7 +7,7 @@ from django.urls import reverse
 from rest_framework.decorators import api_view
 from rest_framework.response import Response
 from rest_framework import status
-from .serializers import PasswordSerializer, UserSerializer, SignInSerializer
+from .serializers import PasswordSerializer, ProfileSerializer, UserSerializer, SignInSerializer
 from django.views.decorators.csrf import csrf_exempt
 
 
@@ -51,22 +51,14 @@ def signin(request):
 def profile(request):
     user = request.user
     if request.method == 'PATCH':
-        serializer = UserSerializer(user, data = request.data, partial = True)
+        serializer = ProfileSerializer(user, data = request.data, partial = True)
         if serializer.is_valid():
-            for field in request.data.keys():
-                if field != "password":
-                    setattr(user, field, request.data[field])
-                else:
-                    user.set_password(request.data[field])
-            user.save()
+            serializer.save()
             logout(request)
             redirect_url = reverse('users:signin')
             return Response({"result": True, "statusCode": 200, "message": "회원 정보 수정이 완료되었습니다.", "redirect_url": redirect_url})
-    elif request.method == "GET":
-        serializer = UserSerializer(user)
-        return render(request, "profile.html", {"user": serializer.data})
-    else:
-        return Response({"result": False, "statusCode": 400, "message": "에러가 발생했습니다."})
+    serializer = ProfileSerializer(user)
+    return render(request, "profile.html", {"user": serializer.data})
 
 
 @login_required


### PR DESCRIPTION
# What I have done

- 프로필 페이지와 비밀번호 변경 페이지를 분리했습니다.
- 프로필 페이지에서 이메일과 닉네임을 수정하기 위해 비밀번호를 요구합니다.
- 비밀번호 수정 시, 기존 비밀번호(password), 새 비밀번호 (password1, password2)를 쳐야만 통과되게 만들었습니다.
- 모든 입력은 예외처리가 되어있습니다 💦

# 예외처리 목록

- Validation
	- password1과 password2가 같은 경우
	- 기존 비밀번호와 새 비밀번호가 같은 경우
	- 기존 비밀번호가 틀린 경우
	- 새 비밀번호가 너무 짧은 등 `AUTH_PASSWORD_VALIDATORS`에 명시된 규칙에 어긋나는 비밀번호를 작성한 경우
- IntegrityError
	- 이메일이 중복되는 경우