### PR TITLE
fix(big): Error handling when data is too big

### DIFF
--- a/products/views.py
+++ b/products/views.py
@@ -1,5 +1,7 @@
+import http
 import json
 import base64
+from django.core.exceptions import RequestDataTooBig
 from django.shortcuts import render, get_object_or_404
 from django.http import JsonResponse, HttpResponse
 from django.contrib.auth.decorators import login_required
@@ -54,7 +56,11 @@ def create_product(request):
                 product.image.save(handle, ContentFile(image_data), save=False)
             product.handle = handle
             product.user = request.user
-            product.save()
+            try:
+                product.save()
+            except RequestDataTooBig as e:
+                return JsonResponse({"message": e}, status=http.HTTPStatus.FORBIDDEN)
+
             return JsonResponse({"message": "신규 도서 등록이 완료되었습니다.", "redirect_url": "/products/book/"})
         else:
             return JsonResponse({"message": form.errors.as_json()})

--- a/templates/create_product.html
+++ b/templates/create_product.html
@@ -28,14 +28,28 @@
 </form>
 
 <script>
-  document.querySelector(".productCreate").addEventListener("submit", function (e) {
-  e.preventDefault();
 
-  const fileInput = document.querySelector("#image");
-  const imageFile = fileInput.files[0];
-
+  const $fileInput = document.querySelector("#image");
   const reader = new FileReader();
-  reader.onloadend = function () {
+  let imageFile = $fileInput.files[0];
+
+  $fileInput.onchange = onChange;
+  reader.onloadend = onLoadend;
+
+  document.querySelector(".productCreate").addEventListener("submit", function (e) {
+    e.preventDefault();
+    reader.readAsDataURL(imageFile);
+  });
+
+  function onChange() {
+    if ($fileInput.files[0].size > 2500000) {
+      alert("2.5MB 이상의 파일은 담을 수 없습니다.");
+      $fileInput.value = null;
+    }
+    imageFile = $fileInput.files[0];
+  }
+
+  function onLoadend() {
     const imageData = reader.result.split(",")[1];
 
     const data = {
@@ -76,22 +90,19 @@
 
           res.json().then(error => {
 
-              alert(error.message);
+            alert(error.message);
 
-            }).catch((e) => {
+          }).catch((e) => {
 
-              alert("JSON 파싱 에러! 콘솔창을 확인하세요.");
-              console.log(e);
-            })
+            alert("JSON 파싱 에러! 콘솔창을 확인하세요.");
+            console.log(e);
+          })
         } else {
           alert("알 수 없는 에러! 콘솔창을 확인하세요.");
           console.log(e);
         }
       });
   };
-
-  reader.readAsDataURL(imageFile);
-});
 
 </script>
 {% endblock content %}

--- a/templates/create_product.html
+++ b/templates/create_product.html
@@ -83,12 +83,9 @@
               alert("JSON 파싱 에러! 콘솔창을 확인하세요.");
               console.log(e);
             })
-        }
-        if (typeof res.json === "function") {
-          
         } else {
           alert("알 수 없는 에러! 콘솔창을 확인하세요.");
-          console.log(res);
+          console.log(e);
         }
       });
   };

--- a/templates/create_product.html
+++ b/templates/create_product.html
@@ -55,10 +55,41 @@
       },
       body: JSON.stringify(data)
     })
-      .then(res => res.json())
+      .then(res => {
+        if (res.status !== 200) {
+          return Promise.reject(res);
+        }
+        return res.json()
+      })
       .then(data => {
         alert(data.message);
         window.location.href = data.redirect_url;
+      }).catch(res => {
+        const contentType = res.headers.get("Content-Type").split(";")[0];
+        if (contentType === "text/html") {
+
+          res.text().then(html => {
+            document.body.innerHTML = html;
+          })
+
+        } else if (contentType === "application/json") {
+
+          res.json().then(error => {
+
+              alert(error.message);
+
+            }).catch((e) => {
+
+              alert("JSON 파싱 에러! 콘솔창을 확인하세요.");
+              console.log(e);
+            })
+        }
+        if (typeof res.json === "function") {
+          
+        } else {
+          alert("알 수 없는 에러! 콘솔창을 확인하세요.");
+          console.log(res);
+        }
       });
   };
 


### PR DESCRIPTION
# What I have done

- 파일 크기가 2.5MB 이상일 경우 프론트에서 입력이 불가하게 수정함.
- 백엔드는 `create_product` view 함수에 도달하기 전에 이미 `RequestDataTooBig` 예외가 발생했기 때문에 미들웨어를 구현해야 함 → 구현안함

# 개선점

- 현재 2.5MB에 대한 정보가 프론트에서 하드코딩되어 있습니다. 이것은 `DATA_UPLOAD_MAX_MEMORY_SIZE`에 저장이 되어있기 때문에 해당 값을 프론트에게 던져주면 좋을 것 같습니다.

```python
# settings.py
DATA_UPLOAD_MAX_MEMORY_SIZE = 2621440 # 2.5MB
```