### PR TITLE
fix(s3): static urls are now s3 url

### DIFF
--- a/core/settings.py
+++ b/core/settings.py
@@ -167,11 +167,9 @@ USE_TZ = True
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/4.2/howto/static-files/
 from core.storages.conf import * #noqa
-STATIC_URL = "/static/"
+STATIC_URL = AWS_S3_URL + "/static/"
 
-STATICFILES_DIRS = [
-    BASE_DIR / "static",
-]
+STATIC_ROOT = os.path.join(BASE_DIR, 'static')
 
 # Default primary key field type
 # https://docs.djangoproject.com/en/4.2/ref/settings/#default-auto-field

--- a/core/storages/backends.py
+++ b/core/storages/backends.py
@@ -1,7 +1,7 @@
-from storages.backends.s3boto3 import S3Boto3Storage
+from storages.backends.s3boto3 import S3Boto3Storage, S3StaticStorage
 
 class MediaStorage(S3Boto3Storage):
     location = "media"
 
-class StaticFileStorage(S3Boto3Storage):
+class StaticFileStorage(S3StaticStorage):
     location = "static"

--- a/core/storages/conf.py
+++ b/core/storages/conf.py
@@ -6,6 +6,7 @@ AWS_S3_ADDRESSING_STYLE = "virtual"
 
 AWS_STORAGE_BUCKET_NAME=config("AWS_STORAGE_BUCKET_NAME", default="estsoft-ormi-bookstore")
 AWS_S3_REGION_NAME="ap-northeast-2"
+AWS_S3_URL = f"https://{AWS_STORAGE_BUCKET_NAME}.s3.amazonaws.com"
 
 AWS_DEFAULT_ACL="public-read"
 AWS_S3_USE_SSL=True

--- a/templates/base.html
+++ b/templates/base.html
@@ -18,8 +18,8 @@
     {% with css_version="2.1" %} {% block stylesheet %}{% endblock stylesheet%}
     {% endwith %}
 
-    <script src="/static/js/getCookie.js"></script>
-    <script src="/static/js/constants.js" type="module"></script>
+    <script src="{% static 'js/getCookie.js' %}"></script>
+    <script src="{% static 'js/constants.js' %}" type="module"></script>
 </head>
 
 <body>

--- a/templates/checkout.html
+++ b/templates/checkout.html
@@ -65,7 +65,7 @@
         convertToJsObject,
         totalSum
     }
-        from "/static/js/orderItem.js";
+        from "{% static 'js/orderItem.js' %}";
 
     const csrftoken = getCookie("csrftoken");
     const $total = document.querySelector("#total");


### PR DESCRIPTION
현재 static파일 (JS)들에 대하여 로컬 주소를 가져오는 문제가 있었습니다. 이것은 우리가 의도한 바가 아니며, `https://{bucket-name}.s3.amazonaws.com`으로 시작하는 URL로 사용하도록 강제했습니다.