### PR TITLE
fix(CORS): Add middleware that appends response header

### DIFF
--- a/core/middleware.py
+++ b/core/middleware.py
@@ -1,0 +1,17 @@
+from django import http
+
+class CorsMiddleware:
+    def __init__(self, get_response):
+        self.get_response = get_response
+    
+    def __call__(self, request):
+        response = self.get_response(request)
+        if (request.method == "OPTIONS"  and "HTTP_ACCESS_CONTROL_REQUEST_METHOD" in request.META):
+            response = http.HttpResponse()
+            response["Content-Length"] = "0"
+            response["Access-Control-Max-Age"] = 86400
+        response["Access-Control-Allow-Origin"] = "*"
+        response["Access-Control-Allow-Methods"] = "DELETE, GET, OPTIONS, PATCH, POST, PUT"
+        response["Access-Control-Allow-Headers"] = "accept, accept-encoding, authorization, content-type, dnt, origin, user-agent, x-csrftoken, x-requested-with"
+        return response
+

--- a/core/settings.py
+++ b/core/settings.py
@@ -58,14 +58,14 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
+    "core.middleware.CorsMiddleware",
+    "django.middleware.common.CommonMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
-    "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
-    'corsheaders.middleware.CorsMiddleware',
 ]
 
 ROOT_URLCONF = "core.urls"
@@ -185,5 +185,25 @@ MEDIA_ROOT = os.path.join(BASE_DIR, 'media')
 
 LOGIN_URL = '/users/signin/'
 
-CORS_ORIGIN_ALLOW_ALL = True
 CORS_ALLOW_CREDENTIALS = True
+CORS_ALLOW_PRIVATE_NETWORK = True
+CORS_ALLOWED_ORIGINS = [
+    "https://allbooks-choi-2.s3.amazonaws.com",
+    "http://13.209.22.220"
+]
+CSRF_TRUSTED_ORIGINS = [
+    "https://allbooks-choi-2.s3.amazonaws.com",
+    "http://13.209.22.220"
+]
+
+from corsheaders.defaults import default_methods
+from corsheaders.defaults import default_headers
+
+CORS_ALLOW_METHODS = (
+    *default_methods,
+)
+
+CORS_ALLOW_HEADERS = (
+    *default_headers,
+)
+


### PR DESCRIPTION
Response header에 Access-Control-Allow-Origin을 추가하여야만 CORS 문제를 해결할 수 있습니다. 

[관련 블로그](https://inpa.tistory.com/entry/WEB-%F0%9F%93%9A-CORS-%F0%9F%92%AF-%EC%A0%95%EB%A6%AC-%ED%95%B4%EA%B2%B0-%EB%B0%A9%EB%B2%95-%F0%9F%91%8F)

[middleware 참고](https://stackoverflow.com/a/58153018/6428901)